### PR TITLE
Define AST_MODULE_SELF_SYM for Asterisk 14+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,21 @@ uninstall:
 	cd $(ASTMODDIR) && rm $(addsuffix .so,$(MODULES))
 
 codec_opus_open_source: LIBS+=-lopus
-codec_opus_open_source: DEFS+=-DAST_MODULE=\"codec_opus_open_source\"
+codec_opus_open_source: DEFS+=-DAST_MODULE=\"codec_opus_open_source\" \
+	-DAST_MODULE_SELF_SYM=__internal_codec_opus_open_source_self
 codec_opus_open_source: codecs/codec_opus_open_source.so
 
 format_ogg_opus_open_source: CPATH+=-I/usr/include/opus
 format_ogg_opus_open_source: LIBS+=-lopus -lopusfile
-format_ogg_opus_open_source: DEFS+=-DAST_MODULE=\"format_ogg_opus_open_source\"
+format_ogg_opus_open_source: DEFS+=-DAST_MODULE=\"format_ogg_opus_open_source\" \
+	-DAST_MODULE_SELF_SYM=__internal_format_ogg_opus_open_source_self
 format_ogg_opus_open_source: formats/format_ogg_opus_open_source.so
 
-format_vp8: DEFS+=-DAST_MODULE=\"format_vp8\"
+format_vp8: DEFS+=-DAST_MODULE=\"format_vp8\" -DAST_MODULE_SELF_SYM=__internal_format_vp8_self
 format_vp8: formats/format_vp8.so
 
-res_format_attr_opus: DEFS+=-DAST_MODULE=\"res_format_attr_opus\"
+res_format_attr_opus: DEFS+=-DAST_MODULE=\"res_format_attr_opus\" \
+	-DAST_MODULE_SELF_SYM=__internal_res_format_attr_opus_self
 res_format_attr_opus: res/res_format_attr_opus.so
 
 .c.so:


### PR DESCRIPTION
This is necessary for external module compilation since Asterisk 14

gcc -o codecs/codec_opus_open_source.so  -DAST_MODULE=\"codec_opus_open_source\" -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/asterisk-opus-13.7+20171009=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -g3 -O3 -lopus -shared -Wl,-z,relro codecs/codec_opus_open_source.c
In file included from codecs/codec_opus_open_source.c:39:
/usr/include/asterisk.h:232:2: error: #error "Externally compiled modules must declare AST_MODULE_SELF_SYM."
 #error "Externally compiled modules must declare AST_MODULE_SELF_SYM."
  ^~~~~
In file included from codecs/codec_opus_open_source.c:56:
codecs/codec_opus_open_source.c: In function 'load_module':
codecs/codec_opus_open_source.c:833:8: error: 'AST_MODULE_SELF' undeclared (first use in this function); did you mean 'AST_MODULE_INFO'?
  res = ast_register_translator(&opustolin);
        ^~~~~~~~~~~~~~~~~~~~~~~
codecs/codec_opus_open_source.c:833:8: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:50: codecs/codec_opus_open_source.so] Error 1

Fixes #15